### PR TITLE
Фикс "Parent instance <User at ...> is not bound to a Session"  в follow/unfollow

### DIFF
--- a/data/users.py
+++ b/data/users.py
@@ -34,8 +34,7 @@ class User(SqlAlchemyBase, SerializerMixin, UserMixin):
             self.follower.remove(group)
 
     def is_following(self, group):
-        return self.follower.filter(
-            user_group.c.followed_id == group.id).count() > 0
+        return group in self.follower
 
     def set_password(self, password):
         self.hashed_password = generate_password_hash(password)

--- a/main.py
+++ b/main.py
@@ -269,6 +269,7 @@ def edit():
 @app.route('/group/<int:id_group>', methods=['GET', 'POST'])
 def group(id_group):
     session = db_session.create_session()
+    user = session.merge(current_user)
     form = PostForm()
     my = g.user.id
     if form.validate_on_submit():
@@ -288,7 +289,7 @@ def group(id_group):
     posts = session.query(Post).filter(Post.autor_id == id_group).order_by(Post.id.desc())
     group_info = session.query(Group).filter_by(id=id_group).first()
     return render_template('group.html', title='Авторизация', form=form, posts=posts, info=group_info,
-                           avatar=group_info.avatar, id=id_group, my=my)
+                           avatar=group_info.avatar, id=id_group, my=my, user=user)
 
 
 @app.route('/groups')
@@ -404,20 +405,21 @@ def gr_post_delete(id):
 @app.route('/follow/<group_id>')
 @login_required
 def follow(group_id):
-    # session = db_session.create_session()
-    # group = session.query(Group).filter_by(id=group_id).first()
-    # current_user.follow(group)
-    # session.commit()
+    session = db_session.create_session()
+    user = session.merge(current_user)
+    group = session.query(Group).filter_by(id=group_id).first()
+    user.follow(group)
+    session.commit()
     return redirect(f'/group/{group_id}')
 
 
 @app.route('/unfollow/<group_id>')
 def unfollow(group_id):
-    # session = db_session.create_session()
-    # group = session.query(Group).filter_by(id=group_id).first()
-    # session.close()
-    # current_user.unfollow(group)
-    # session.commit()
+    session = db_session.create_session()
+    user = session.merge(current_user)
+    group = session.query(Group).filter_by(id=group_id).first()
+    user.unfollow(group)
+    session.commit()
     return redirect(f'/')
 
 

--- a/templates/group.html
+++ b/templates/group.html
@@ -22,12 +22,12 @@
                         <h6>{{info.info}}</h6>
                           {% if my != '0' %}
                             <div class="btn-group" role="group" aria-label="Basic example">
-                              {% if not current_user.is_following(info) %}
+                              {% if not user.is_following(info) %}
                                     <a class="btn btn-outline-warning my-2 my-sm-0" href="/follow/{{info.id}}">Follow</a></p>
                               {% else %}
                                     <a class="btn btn-outline-warning my-2 my-sm-0" href="/unfollow/{{info.id}}">Unfollow</a></p>
                               {% endif %}
-                              {% if current_user.id == info.admin%}
+                              {% if user.id == info.admin%}
                                 <a class="btn btn-outline-warning my-2 my-sm-0" href="/group_edit/{{info.id}}">Edit</a>
                               {% endif %}
                           </div>


### PR DESCRIPTION
Объект `current_user` получается из другой сессии (которую открывал когда-то давно и закрыл уже `flask_login`). И всё бы ничего, но список групп подгружается лениво (то есть потом, по мере необходимости), а подгрузить его уже неоткуда, потому что сессия, к которой этот объект относился, уже закрылась, и он получается как бы оторван от базы данных.

Подробно про это всё можно почитать тут https://docs.sqlalchemy.org/en/13/orm/session_state_management.html?highlight=object%20states#quickie-intro-to-object-states